### PR TITLE
Allow running `check consistency` on tidb v4.0.x

### DIFF
--- a/cmd/check/consistency.go
+++ b/cmd/check/consistency.go
@@ -54,10 +54,10 @@ func checkRows(opts checkRowsOpts) error {
 	defer client.Close()
 
 	if err = client.ExecWithElapsed("set tidb_allow_batch_cop = 0"); err != nil {
-		return err
+		fmt.Printf("tidb_allow_batch_cop is ignored")
 	}
 	if err = client.ExecWithElapsed("set tidb_allow_mpp = 0"); err != nil {
-		return err
+		fmt.Printf("tidb_allow_mpp = 0 is ignored")
 	}
 
 	queryRanges, err := getInitQueryRange(client.Db, opts)


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

Before
```
>  ./bin/tiflash-ctl check consistency --tidb_ip=127.0.0.1 --tidb_port=37115 --database=test --table=a
set tidb_allow_batch_cop = 0 => 3ms
set tidb_allow_mpp = 0 => 0ms
Error: Error 1193: Unknown system variable 'tidb_allow_mpp'
```

After
```
>  ./bin/tiflash-ctl check consistency --tidb_ip=127.0.0.1 --tidb_port=37115 --database=test --table=a
set tidb_allow_batch_cop = 0 => 4ms
set tidb_allow_mpp = 0 => 0ms
tidb_allow_mpp = 0 is ignoredselect min(_tidb_rowid), max(_tidb_rowid) from `test`.`a` => 2ms (tikv)
select min(_tidb_rowid), max(_tidb_rowid) from `test`.`a` => 4ms (tiflash)
RowID range: [1, 1] (tikv)
RowID range: [1, 1] (tiflash)
Init query ranges: [[1, 2)]
select count(*) from `test`.`a` where 1 <= _tidb_rowid and _tidb_rowid < 2 => 1ms (tikv)
select count(*) from `test`.`a` where 1 <= _tidb_rowid and _tidb_rowid < 2 => 1ms (tiflash)
select count(*) from `test`.`a` where 1 <= _tidb_rowid and _tidb_rowid < 2 => 0ms (tikv)
select count(*) from `test`.`a` where 1 <= _tidb_rowid and _tidb_rowid < 2 => 1ms (tiflash)
Range [1, 2), num of rows: tikv 1, tiflash 1. OK
```